### PR TITLE
Add client max method, fix `.excluding` bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.2
+Bug fix: `.excluding()` did not listen for remove events on exclusion lists. If a client was removed yet still connected, it wouldn't make it into the exclusion set.<br />
+Bug fix: the "add" event would fire each time you add the same client, even though it was already contained.
+Feature: New `clients.pluck(Number)` method will create a new list constrained to a maximum number of clients.
+
 ## v0.2.1
 The `ClientList` constructor has been exposed as `panic.ClientList`, and now accepts an array of smaller lists to pull from.
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ var client = {
 **Table of Contents**
  - [`.filter()`](#filter)
  - [`.excluding()`](#excluding)
+ - [`.pluck()`](#pluck)
  - [`.run()`](#run)
  - [`.len()`](#len)
  - [`.get()`](#get)
@@ -268,6 +269,33 @@ Like filter, you can chain queries off each other to create really powerful quer
 var chrome = browsers.filter('Chrome')
 var notChrome = browsers.excluding(chrome)
 ```
+
+##### <a name='pluck'></a> `.pluck(Number)`
+`.pluck` restricts the list length to a number, reactively listening for changes to ensure it's as close to the maximum as it can be. An excellent use case for `.pluck` is singling out clients of the same platform. This becomes especially powerful when paired with [`.excluding`](#excluding) and the `ClientList` constructor. For example, if you want to control 3 clients individually, it might look like this:
+
+```javascript
+var clients = panic.clients
+var List = panic.ClientList
+
+// grab one client from the list
+var alice = clients.pluck(1)
+
+// grab another, so long as it isn't alice
+var bob = clients
+.excluding(alice)
+.pluck(1)
+
+// and another, so long as it isn't alice or bob
+var carl = clients
+.excluding(
+	new List([ alice, bob ])
+)
+.pluck(1)
+```
+
+> `.pluck` is highly reactive, and will readjust itself to hold as many clients as possible.
+
+> **Warning:** the method name may change.
 
 ##### <a name='run'></a> `.run(Function[, Object])`
 `.run` is where the magic happens. This method allows you to evaluate a function on all platforms belonging to this list, and reject or resolve a promise when either everyone finishes or one fails. Asynchronous code is supported.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panic-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Distributed Javascript runner",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
There's a new method called `.pluck` that limits a list's length,
allowing you to arbitrarily pick out clients and select them for tasks.
The version has been bumped, changelog updated and readme modified.
Also, the `.excluding` method wasn't reactively checking to see if the
exclusion set was reduced, only added to. All tests passing.