### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 ## v0.3.0
-Improvements: deprecated `.len()` in favor of `.length`, allow ClientList to be subclassable, and lazily export the client code onto the `panic.client` property.
+Breaking changes:
+ - position of the `done` changed to the first parameter. `this` context is no longer passed.
+ - `.len()` has been deprecated in favor of `.length`.
+ - `export vars` is no longer enabled by default, but opt-in using the `{ '@scope': true }` property.
+
+Improvements:
+ - allow ClientList to be subclassable
+ - lazily export the client code onto the new `panic.client` property
 
 Subclassing is curtesy of a new method, `.chain`, which ensures the `this` context's constructor is called instead of statically calling `new ClientList()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.0
+Improvements: deprecated `.len()` in favor of `.length`, allow ClientList to be subclassable, and lazily export the client code onto the `panic.client` property.
+
+Subclassing is curtesy of a new method, `.chain`, which ensures the `this` context's constructor is called instead of statically calling `new ClientList()`.
+
 ## v0.2.4
 Set the `constructor` property on the ClientList prototype.
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ clients.filter('Node.js').run(function () {
 
 The function passed is first stringified, then sent to the clients for evaluation. When it's invoked on the client, it's given a special `this` context and some control parameters to work with async data.
 
-The function is passed two parameters: the `this` context, and the `done` callback. If the callback is set as a parameter, it's assumed that the code is asynchronous and won't report a `done` event until the callback is invoked or an error is thrown.
+The function is passed one parameter: a `done` callback. If takes a parameter, it's assumed that the code is asynchronous and won't report a `done` event until the callback is invoked or an error is thrown.
 
 After sending off your function, `.run` returns a promise. When every client has finished running the code, the promise fulfills. If you're not familiar with promises, I recommend reading the [MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). They're an invaluable tool and native support is well on it's way. They're also incredibly useful when paired with `.run`.
 
@@ -331,7 +331,7 @@ For example, you could have a list of 100 browsers, and perhaps you want each of
 var servers = clients.filter('Node.js')
 var browsers = clients.excluding(servers)
 
-function loadExpectJS(browser, done) {
+function loadExpectJS(done) {
 	// create a script element
 	var script = document.createElement('script')
 
@@ -415,21 +415,9 @@ However, that none of them are necessary to use panic-server.
 ##### `.run` scope controls
 This section is gonna be a little tricky, hold on...
 
-`.run` allows you to send local variables to the clients and continue using them as locals. If you're familiar with Javascript's [`with`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with) statement, it's basically a fancy `with`.
+`.run` allows you to send local variables to the clients and continue using them as locals. If you're familiar with Javascript's [`with`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with) statement, it's basically a fancy `with`, but don't worry, it's opt in. Let's show a simpler case first...
 
-By passing an object as the second parameter, you can export variables into the callback as local scope variables.
-
-```javascript
-clients.run(function () {
-	console.log(localVariable) // 'visible'
-	console.log(numbers) // array
-}, {
-	localVariable: 'visible',
-	numbers: [1, 2, 3, 5, 8]
-})
-```
-
-Alternatively, all variables are accessable in the `this.data` object:
+By passing an object as the second parameter, you'll be able to use them on the client by accessing `this.data`.
 
 ```javascript
 clients.run(function (client) {
@@ -444,10 +432,23 @@ clients.run(function (client) {
 })
 ```
 
+If you set `'@scope'` to `true` on your object, it'll export those variables into the local scope of your callback.
+
+```javascript
+clients.run(function () {
+	console.log(localVariable) // 'visible'
+	console.log(numbers) // array
+}, {
+	localVariable: 'visible',
+	numbers: [1, 2, 3, 5, 8],
+	'@scope': true
+})
+```
+
 In this way, you can share variables on the server with the clients without duplicating code. This is also useful for injecting variables into a mixin, like `loadScript`:
 
 ```javascript
-function loadScript(client, done) {
+function loadScript(done) {
 	var script = document.createElement('script');
 
 	// use the exported `src` variable
@@ -459,18 +460,18 @@ function loadScript(client, done) {
 
 // expose the `src` variable
 clients.run(loadScript, {
-	src: 'http://...'
+	src: 'http://...',
+	'@scope': true
 })
 ```
 
-Some Javascript linters may complain about using undefined variables, in which case you can either turn off the linter rule, or use `this.data` and disable the local variable injection by setting a flag in the scope object, called 'export vars'.
+Some Javascript linters may complain about using undefined variables, in which case you can either turn off the linter rule, or use `this.data`. If you're planning on maintaining the code long-term, I'd recommend using `this.data`.
 
 ```javascript
 clients.run(function () {
 	typeof src; // 'undefined'
 	this.data.src; // 'http://...'
 }, {
-	'export vars': false,
 	src: 'http://...'
 })
 ```
@@ -527,6 +528,18 @@ sub.chain().coolNewMethod() // properly inherits
 ```
 
 If you're making an extension that creates a new list instance, use this method to play nice with other extensions.
+
+## Roadmap
+The goal is to keep panic light-weight and modular. Future releases will likely be aimed at improving the plugin system and fixing any egregious bugs or compatibility issues. That said, there are some features we really want first...
+
+ - Allow clients to send back non-error data (through either the `done` callback or a continuous data stream) to enable ssh-style apps.
+
+ - Catch and report asynchronously thrown errors on...
+	 - **Node.js:** feasible by listening for UncaughtException on `global.process`.
+
+	 - **Browsers:** sounds easy in practice, but the browser is a place filled with pain and misery that makes that a really hard thing. Please tell me if you've got a better idea than `window.onerror` :pray:
+
+ - Implement an underlying `Client` interface that the ClientList builds on. The idea is to separate concerns and abstract the transport layer, UIDs, and job runners.
 
 ## Support
 If you have questions or ideas, we'd love to hear them! Just swing by our [gitter channel](https://gitter.im/amark/gun) and ask for @PsychoLlama or @amark. We're usually around :wink:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/gundb/panic-server#readme",
   "dependencies": {
     "bluebird": "^3.3.5",
-    "panic-client": "^0.1.0",
+    "panic-client": "^0.2.0",
     "socket.io": "^1.4.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panic-server",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Distributed Javascript runner",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,5 @@
 'use strict';
-var server = require('./server');
-var clients = require('./clients');
-var ClientList = require('./ClientList');
 
-var msg = '\n\nAPI CHANGE: ".serve()" has been renamed to ".server()",\n' +
-'and no longer works the same (see changelog#v0.2.0).\n';
-
-module.exports = {
-	server: server,
-	serve: function () {
-		throw new Error(msg);
-	},
-	clients: clients,
-	ClientList: ClientList
-};
+exports.server = require('./server');
+exports.clients = require('./clients');
+exports.ClientList = require('./ClientList');

--- a/src/server.js
+++ b/src/server.js
@@ -1,13 +1,26 @@
+/*eslint-disable no-sync*/
 'use strict';
+
 var io = require('socket.io');
 var fs = require('fs');
 var clients = require('./clients');
 var file = require.resolve('panic-client/panic.js');
 var Server = require('http').Server;
+var panic = require('./index');
+var client;
+
+Object.defineProperty(panic, 'client', {
+	get: function () {
+		if (!client) {
+			client = fs.readFileSync(file, 'utf8');
+		}
+		return client;
+	}
+});
 
 function serve(req, res) {
 	if (req.url === '/panic.js') {
-		fs.createReadStream(file).pipe(res);
+		res.end(panic.client);
 	}
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -35,22 +35,22 @@ describe('A clientList', function () {
 
 	it('should return length when "len()" is called', function () {
 		list.add(client);
-		expect(list.len()).to.eq(1);
+		expect(list.length).to.eq(1);
 		list.remove(client);
-		expect(list.len()).to.eq(0);
+		expect(list.length).to.eq(0);
 	});
 
 	it('should not add disconnected clients', function () {
 		client.socket.connected = false;
 		list.add(client);
-		expect(list.len()).to.eq(0);
+		expect(list.length).to.eq(0);
 	});
 
 	it('should remove a client on disconnect', function () {
 		list.add(client);
-		expect(list.len()).to.eq(1);
+		expect(list.length).to.eq(1);
 		client.socket.emit('disconnect');
-		expect(list.len()).to.eq(0);
+		expect(list.length).to.eq(0);
 	});
 
 	it('should resolve a promise when all clients finish', function (done) {
@@ -88,11 +88,11 @@ describe('A clientList', function () {
 	describe('filter', function () {
 		it('should not mutate the original list', function () {
 			list.add(client);
-			expect(list.len()).to.eq(1);
+			expect(list.length).to.eq(1);
 			list.filter(function () {
 				return false;
 			});
-			expect(list.len()).to.eq(1);
+			expect(list.length).to.eq(1);
 		});
 
 		it('should return a new, filtered list', function () {
@@ -101,15 +101,15 @@ describe('A clientList', function () {
 			var browsers = list.filter(function (client) {
 				return client.platform.name !== 'Node.js';
 			});
-			expect(servers.len()).to.eq(1);
-			expect(browsers.len()).to.eq(0);
+			expect(servers.length).to.eq(1);
+			expect(browsers.length).to.eq(0);
 		});
 
 		it('should be reactive to changes to the parent list', function () {
 			var servers = list.filter('Node.js');
-			expect(servers.len()).to.eq(0);
+			expect(servers.length).to.eq(0);
 			list.add(client);
-			expect(servers.len()).to.eq(1);
+			expect(servers.length).to.eq(1);
 		});
 	});
 
@@ -117,7 +117,7 @@ describe('A clientList', function () {
 		it('should not contain excluded clients', function () {
 			list.add(client);
 			var filtered = list.excluding(list);
-			expect(filtered.len()).to.eq(0);
+			expect(filtered.length).to.eq(0);
 		});
 
 		it('should react to removals if they are connected', function () {
@@ -127,9 +127,9 @@ describe('A clientList', function () {
 			.add(decoy);
 			var filtered = list.excluding(exclusion);
 			list.add(client).add(new Client());
-			expect(filtered.len()).to.eq(1);
+			expect(filtered.length).to.eq(1);
 			exclusion.remove(client).remove(decoy);
-			expect(filtered.len()).to.eq(2);
+			expect(filtered.length).to.eq(2);
 		});
 	});
 
@@ -138,26 +138,26 @@ describe('A clientList', function () {
 			list.add(client)
 			.add(new Client())
 			.add(new Client());
-			expect(list.pluck(1).len()).to.eq(1);
+			expect(list.pluck(1).length).to.eq(1);
 		});
 
 		it('should listen for additions', function () {
 			var subset = list.pluck(2);
-			expect(subset.len()).not.to.eq(2);
+			expect(subset.length).not.to.eq(2);
 			list.add(new Client()).add(new Client());
-			expect(subset.len()).to.eq(2);
+			expect(subset.length).to.eq(2);
 			list.add(new Client());
-			expect(subset.len()).to.eq(2);
+			expect(subset.length).to.eq(2);
 		});
 
 		it('should replace a client when it disconnects', function () {
 			var subset = list.pluck(1);
 			list.add(client).add(new Client());
-			expect(subset.len()).to.eq(1);
+			expect(subset.length).to.eq(1);
 			client.socket.emit('disconnect');
 			// It should be replaced with
 			// the second connected client.
-			expect(subset.len()).to.eq(1);
+			expect(subset.length).to.eq(1);
 		});
 
 		it('should set a flag whether the constraint is met', function () {
@@ -175,8 +175,8 @@ describe('A clientList', function () {
 			list.add(client)
 			.add(new Client())
 			.add(new Client());
-			expect(alice.len()).to.eq(1);
-			expect(bob.len()).to.eq(1);
+			expect(alice.length).to.eq(1);
+			expect(bob.length).to.eq(1);
 		});
 	});
 });
@@ -207,5 +207,20 @@ describe('The ClientList constructor', function () {
 		expect(list.get(client3.socket.id)).to.eq(null);
 		list1.add(client3);
 		expect(list.get(client3.socket.id)).to.eq(client3);
+	});
+
+	it('should be subclassable', function () {
+		function Sub() {
+			ClientList.call(this);
+		}
+		Sub.prototype = new ClientList();
+		Sub.prototype.constructor = Sub;
+
+		var sub = new Sub();
+		expect(sub).to.be.an.instanceof(Sub);
+
+		// chained inheritance
+		expect(sub.filter('Firefox')).to.be.an.instanceof(Sub);
+		expect(sub.pluck(1)).to.be.an.instanceof(Sub);
 	});
 });


### PR DESCRIPTION
 - Upgrade to panic-client v0.2 (IE6, better async support, better scope management)
 - Improve pluggability for the `ClientList` constructor
 - Lazily export the client bundle
 - Rename `.len()` to `.length`
 - Add new method for managed subclassing